### PR TITLE
FIX: loginProviderName requirement for remote-role based authenticati…

### DIFF
--- a/f5/f5.go
+++ b/f5/f5.go
@@ -45,11 +45,11 @@ func NewBasicClient(baseURL, user, password string) (*Client, error) {
 // NewTokenClient creates a new F5 client with token based authentication.
 //
 // baseURL is the base URL of the F5 API server.
-func NewTokenClient(baseURL, user, password, loginRef string, sslCheck bool) (*Client, error) {
+func NewTokenClient(baseURL, user, password, loginProvName string, sslCheck bool) (*Client, error) {
 	c := Client{c: http.Client{}, baseURL: baseURL}
 
 	// Negociate token with a pair of username/password.
-	data, err := json.Marshal(map[string]string{"username": user, "password": password, "loginReference": loginRef})
+	data, err := json.Marshal(map[string]string{"username": user, "password": password, "loginProviderName": loginProvName})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create token client (cannot marshal user credentials): %v", err)
 	}


### PR DESCRIPTION
Just some context. I am running into the following issue when attempting to authenticate a remote-role for token-based authentication:

failed to create token client (token negociation failed): http status 400 Bad Requestexit status 1

Looking over the F5 documentation,
https://devcentral.f5.com/articles/demystifying-icontrol-rest-part-6-token-based-authentication

It appears that the required payload needs the loginProviderName element.
Sample Payload:
{
"username": "remote_auth_user",
"password": "remote_auth_password",
"loginProviderName": "tmos"
}

Once this was adjusted, it is working as expected. Let me know if I went about this the wrong way.

Thank you!
Josh