### PR TITLE
test: go test fail

### DIFF
--- a/f5/example_test.go
+++ b/f5/example_test.go
@@ -98,15 +98,7 @@ func Example_transaction() {
 		SourceAddressTranslation: ltm.SourceAddressTranslation{
 			Type: "automap",
 		},
-		Profiles: []ltm.Profile{
-			{
-				Name:    "tcp-mobile-optimized",
-				Context: "all",
-			},
-			{
-				Name: "http",
-			},
-		},
+        Profiles: []string{"tcp-mobile-optimized"},
 	}
 
 	if err := ltmClient.Virtual().Create(vsConfig); err != nil {


### PR DESCRIPTION
get the error:
```
./example_test.go:101:3: cannot use []ltm.Profile{...} (type []ltm.Profile) as type []string in field value
FAIL	github.com/e-XpertSolutions/f5-rest-client.git [build failed]
```